### PR TITLE
Admin Message edit form

### DIFF
--- a/mailer/admin.py
+++ b/mailer/admin.py
@@ -1,10 +1,12 @@
 from django.contrib import admin
 
 from mailer.models import Message, DontSendEntry, MessageLog
+from mailer.forms import MessageForm
 
 
 class MessageAdmin(admin.ModelAdmin):
     list_display = ["id", "to_addresses", "subject", "when_added", "priority"]
+    form = MessageForm
 
 
 class DontSendEntryAdmin(admin.ModelAdmin):

--- a/mailer/engine.py
+++ b/mailer/engine.py
@@ -77,7 +77,7 @@ def send_all():
             try:
                 if connection is None:
                     connection = get_connection(backend=EMAIL_BACKEND)
-                logging.info("sending message '%s' to %s" % (message.subject.encode("utf-8"), u", ".join(message.to_addresses).encode("utf-8")))
+                logging.info("sending message '%s' to %s" % (message.subject.encode("utf-8"), message.to_addresses.encode("utf-8")))
                 email = message.email
                 email.connection = connection
                 email.send()

--- a/mailer/forms.py
+++ b/mailer/forms.py
@@ -1,0 +1,38 @@
+import re
+
+from django import forms
+
+from mailer.models import Message, make_message
+
+
+class MessageForm(forms.ModelForm):
+    from_email = forms.CharField()
+    to = forms.CharField()
+    subject = forms.CharField()
+    body = forms.CharField(widget=forms.Textarea())
+
+    def __init__(self, *args, **kwargs):
+        instance = kwargs.get('instance')
+        if instance:
+            if not kwargs.get('initial'):
+                kwargs['initial'] = {}
+            kwargs['initial']['from_email'] = instance.from_address
+            kwargs['initial']['to'] = instance.to_addresses
+            kwargs['initial']['subject'] = instance.subject
+            kwargs['initial']['body'] = instance.body
+        return super(MessageForm, self).__init__(*args, **kwargs)
+
+    def save(self, commit=True):
+        instance = super(MessageForm, self).save(commit=False)
+        instance = make_message(db_msg=instance,
+                                from_email=self.cleaned_data['from_email'],
+                                to=re.split(", *", self.cleaned_data['to']),
+                                subject=self.cleaned_data['subject'],
+                                body=self.cleaned_data['body'])
+        if commit:
+            instance.save()
+        return instance
+
+    class Meta:
+        model = Message
+        fields = ('from_email', 'to', 'subject', 'body', 'when_added', 'priority')

--- a/mailer/forms.py
+++ b/mailer/forms.py
@@ -2,16 +2,17 @@ import re
 
 from django import forms
 from django.core.mail import EmailMultiAlternatives
+from django.contrib.admin.widgets import AdminTextInputWidget, AdminTextareaWidget
 
 from mailer.models import Message, make_message
 
 
 class MessageForm(forms.ModelForm):
-    from_email = forms.CharField()
-    to = forms.CharField()
-    subject = forms.CharField()
-    body = forms.CharField(widget=forms.Textarea())
-    body_html = forms.CharField(required=False, widget=forms.Textarea())
+    from_email = forms.CharField(widget=AdminTextInputWidget())
+    to = forms.CharField(widget=AdminTextInputWidget())
+    subject = forms.CharField(widget=AdminTextInputWidget())
+    body = forms.CharField(widget=AdminTextareaWidget)
+    body_html = forms.CharField(required=False, widget=AdminTextareaWidget)
 
     def __init__(self, *args, **kwargs):
         instance = kwargs.get('instance')
@@ -46,4 +47,4 @@ class MessageForm(forms.ModelForm):
 
     class Meta:
         model = Message
-        fields = ('from_email', 'to', 'subject', 'body', 'when_added', 'priority')
+        fields = ('from_email', 'to', 'subject', 'body', 'body_html', 'when_added', 'priority')

--- a/mailer/models.py
+++ b/mailer/models.py
@@ -270,7 +270,7 @@ class MessageLog(models.Model):
     def to_addresses(self):
         email = self.email
         if email is not None:
-            return email.to
+            return u", ".join(email.to)
         else:
             return []
     

--- a/mailer/models.py
+++ b/mailer/models.py
@@ -115,6 +115,14 @@ class Message(models.Model):
 set the attribute again to cause the underlying serialised data to be updated.""")
     
     @property
+    def from_address(self):
+        email = self.email
+        if email is not None:
+            return email.from_email
+        else:
+            return []
+    
+    @property
     def to_addresses(self):
         email = self.email
         if email is not None:
@@ -127,6 +135,14 @@ set the attribute again to cause the underlying serialised data to be updated.""
         email = self.email
         if email is not None:
             return email.subject
+        else:
+            return ""
+    
+    @property
+    def body(self):
+        email = self.email
+        if email is not None:
+            return email.body
         else:
             return ""
 

--- a/mailer/models.py
+++ b/mailer/models.py
@@ -126,7 +126,7 @@ set the attribute again to cause the underlying serialised data to be updated.""
     def to_addresses(self):
         email = self.email
         if email is not None:
-            return email.to
+            return u", ".join(email.to)
         else:
             return []
     

--- a/mailer/models.py
+++ b/mailer/models.py
@@ -145,6 +145,16 @@ set the attribute again to cause the underlying serialised data to be updated.""
             return email.body
         else:
             return ""
+    
+    @property
+    def body_html(self):
+        email = self.email
+        try:
+            for alternative in email.alternatives:
+                if alternative[1] == 'text/html':
+                    return alternative[0]
+        except AttributeError:
+            return ""
 
 
 def filter_recipient_list(lst):

--- a/mailer/models.py
+++ b/mailer/models.py
@@ -160,7 +160,7 @@ def filter_recipient_list(lst):
 
 
 def make_message(subject="", body="", from_email=None, to=None, bcc=None,
-                 attachments=None, headers=None, priority=None):
+                 attachments=None, headers=None, priority=None, db_msg=None):
     """
     Creates a simple message for the email parameters supplied.
     The 'to' and 'bcc' lists are filtered using DontSendEntry.
@@ -175,7 +175,8 @@ def make_message(subject="", body="", from_email=None, to=None, bcc=None,
     core_msg = EmailMessage(subject=subject, body=body, from_email=from_email,
                             to=to, bcc=bcc, attachments=attachments, headers=headers)
     
-    db_msg = Message(priority=priority)
+    if not db_msg:
+        db_msg = Message(priority=priority)
     db_msg.email = core_msg
     return db_msg
 


### PR DESCRIPTION
I created a custom admin form for the `Message` model so that e-mails can actually be edited.  It works for plain text e-mails and HTML e-mails.

The only things I added besides the form itself are:

* `to_addresses` property in `Message` and `MessageLog` returns a comma-delimited list instead of a list of e-mails
* added `from_address`, body, and `body_html` properties to `Message`
* `make_message` can accept a `Message` instance to modify through the optional keyword argument `db_msg`